### PR TITLE
Updating 2.0/.sti/bin/assemble …

### DIFF
--- a/2.0/.sti/bin/assemble
+++ b/2.0/.sti/bin/assemble
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function rake_assets_precompile() {
-  [ -n $DISABLE_ASSET_COMPILATION ] && return
+  [ -n "$DISABLE_ASSET_COMPILATION" ] && return
   [ ! -f Gemfile ] && return
   [ ! -f Rakefile ] && return
   ! grep " rails " Gemfile.lock >/dev/null && return
@@ -16,6 +16,9 @@ function rake_assets_precompile() {
 source .bashrc
 
 set -e
+
+export RACK_ENV=${RACK_ENV:-"production"}
+export RAILS_ENV=${RAILS_ENV:-"${RACK_ENV}"}
 
 echo "---> Installing application source"
 cp -Rf /tmp/src/* ./


### PR DESCRIPTION
to provide default environment as production like in .sti/bin/run and surrounded $DISABLE_ASSET_COMPILATION check with quotes due to not evaluating as true when empty.