### PR TITLE
Drop labels with 'slash' syntax.

### DIFF
--- a/2.0/Dockerfile.rhel7
+++ b/2.0/Dockerfile.rhel7
@@ -14,11 +14,6 @@ LABEL io.k8s.description="Platform for building and running Ruby 2.0 application
       io.openshift.expose-services="8080:http" \
       io.openshift.tags="builder,ruby,ruby20"
 
-LABEL k8s.io/description="Platform for building and running Ruby 2.0 applications" \
-      k8s.io/display-name="Ruby 2.0" \
-      openshift.io/expose-services="8080:http" \
-      openshift.io/tags="builder,ruby,ruby20"
-
 # Labels consumed by Red Hat build service
 LABEL BZComponent="openshift-sti-ruby-docker" \
       Name="openshift3/ruby-20-rhel7" \

--- a/2.2/Dockerfile.rhel7
+++ b/2.2/Dockerfile.rhel7
@@ -12,11 +12,6 @@ LABEL io.k8s.description="Platform for building and running Ruby 2.2 application
       io.openshift.expose-services="8080:http" \
       io.openshift.tags="builder,ruby,ruby22"
 
-LABEL k8s.io/description="Platform for building and running Ruby 2.2 applications" \
-      k8s.io/display-name="Ruby 2.2" \
-      openshift.io/expose-services="8080:http" \
-      openshift.io/tags="builder,ruby,ruby22"
-
 # Labels consumed by Red Hat build service
 LABEL BZComponent="rh-ruby22" \
       Name="openshift3/ruby-22-rhel7" \


### PR DESCRIPTION
Orignially discussed here: https://github.com/openshift/sti-ruby/pull/56#discussion_r35660800

@soltysh This PR removes it from ruby22 image, not sure if I should remove it from ruby20 as well.