### PR TITLE
Strip any addition ror pkgs from ruby22 image (fixes #57).

### DIFF
--- a/2.2/.sti/bin/assemble
+++ b/2.2/.sti/bin/assemble
@@ -15,7 +15,6 @@ function rake_assets_precompile() {
 set -e
 
 export RACK_ENV=${RACK_ENV:-"production"}
-export RAILS_ENV=${RAILS_ENV:-"${RACK_ENV}"}
 
 echo "---> Installing application source ..."
 cp -Rf /tmp/src/. ./

--- a/2.2/.sti/bin/run
+++ b/2.2/.sti/bin/run
@@ -8,7 +8,6 @@ function is_puma_installed() {
 set -e
 
 export RACK_ENV=${RACK_ENV:-"production"}
-export RAILS_ENV=${RAILS_ENV:-"${RACK_ENV}"}
 
 if is_puma_installed; then
   exec bundle exec "puma --config ../etc/puma.cfg"

--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -17,9 +17,8 @@ LABEL io.k8s.description="Platform for building and running Ruby 2.2 application
 RUN yum install -y \
     https://www.softwarecollections.org/en/scls/rhscl/v8314/epel-7-x86_64/download/rhscl-v8314-epel-7-x86_64.noarch.rpm \
     https://www.softwarecollections.org/en/scls/rhscl/rh-ruby22/epel-7-x86_64/download/rhscl-rh-ruby22-epel-7-x86_64.noarch.rpm \
-    https://www.softwarecollections.org/en/scls/rhscl/rh-ror41/epel-7-x86_64/download/rhscl-rh-ror41-epel-7-x86_64.noarch.rpm \
     https://www.softwarecollections.org/en/scls/rhscl/nodejs010/epel-7-x86_64/download/rhscl-nodejs010-epel-7-x86_64.noarch.rpm && \
-    yum install -y --setopt=tsflags=nodocs rh-ruby22 rh-ruby22-ruby-devel rh-ruby22-rubygem-rake v8314 rh-ruby22-rubygem-bundler rh-ror41-rubygem-rack nodejs010 && \
+    yum install -y --setopt=tsflags=nodocs rh-ruby22 rh-ruby22-ruby-devel rh-ruby22-rubygem-rake v8314 rh-ruby22-rubygem-bundler nodejs010 && \
     yum clean all -y
 
 # Copy the STI scripts from the specific language image to /usr/local/sti

--- a/2.2/Dockerfile.rhel7
+++ b/2.2/Dockerfile.rhel7
@@ -19,7 +19,7 @@ LABEL BZComponent="rh-ruby22" \
       Release="1" \
       Architecture="x86_64"
 
-RUN yum install -y --setopt=tsflags=nodocs rh-ruby22 rh-ruby22-ruby-devel rh-ruby22-rubygem-rake v8314 rh-ruby22-rubygem-bundler rh-ror41-rubygem-rack nodejs010 && \
+RUN yum install -y --setopt=tsflags=nodocs rh-ruby22 rh-ruby22-ruby-devel rh-ruby22-rubygem-rake v8314 rh-ruby22-rubygem-bundler nodejs010 && \
     yum clean all -y
 
 # Copy the STI scripts from the specific language image to /usr/local/sti

--- a/2.2/contrib/etc/puma.cfg
+++ b/2.2/contrib/etc/puma.cfg
@@ -1,4 +1,4 @@
-environment ENV['RACK_ENV'] || ENV['RAILS_ENV'] || 'production'
+environment ENV['RACK_ENV'] || 'production'
 threads     0, 16
 workers     0
 bind        'tcp://0.0.0.0:8080'

--- a/2.2/contrib/etc/scl_enable
+++ b/2.2/contrib/etc/scl_enable
@@ -3,4 +3,4 @@
 #
 # This will make scl collection binaries work out of box.
 unset BASH_ENV PROMPT_COMMAND ENV
-source scl_source enable rh-ruby22 rh-ror41 nodejs010
+source scl_source enable rh-ruby22 nodejs010


### PR DESCRIPTION
This should be the same as #58 for ruby 22

Nevertheless, I don't understand, why RAILS_ENV was removed but RACK_ENV kept. @jhadvig do you mind to explain?