### PR TITLE
Remove MAINTAINER in RHEL image

### DIFF
--- a/2.0/Dockerfile.rhel7
+++ b/2.0/Dockerfile.rhel7
@@ -3,8 +3,6 @@ FROM openshift/base-rhel7
 # This image provides a Ruby 2.0 environment you can use to run your Ruby
 # applications.
 
-MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
-
 EXPOSE 8080
 
 ENV RUBY_VERSION 2.0

--- a/2.2/Dockerfile.rhel7
+++ b/2.2/Dockerfile.rhel7
@@ -3,8 +3,6 @@ FROM openshift/base-rhel7
 # This image provides a Ruby 2.2 environment you can use to run your Ruby
 # applications.
 
-MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
-
 EXPOSE 8080
 
 ENV RUBY_VERSION 2.2


### PR DESCRIPTION
It is recommended not to use MAINTAINER in RHEL images.