### PR TITLE
DISABLE_ASSET_COMPILATION variable value

### DIFF
--- a/2.0/s2i/bin/assemble
+++ b/2.0/s2i/bin/assemble
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function rake_assets_precompile() {
-  [ -n "$DISABLE_ASSET_COMPILATION" ] && return
+  [[ "$DISABLE_ASSET_COMPILATION" == "true" ]] && return
   [ ! -f Gemfile ] && return
   [ ! -f Rakefile ] && return
   ! grep " rails " Gemfile.lock >/dev/null && return

--- a/2.2/s2i/bin/assemble
+++ b/2.2/s2i/bin/assemble
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function rake_assets_precompile() {
-  [ -n "$DISABLE_ASSET_COMPILATION" ] && return
+  [[ "$DISABLE_ASSET_COMPILATION" == "true" ]] && return
   [ ! -f Gemfile ] && return
   [ ! -f Rakefile ] && return
   ! grep " rails " Gemfile.lock >/dev/null && return

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ file inside your source code repository.
 
 * **DISABLE_ASSET_COMPILATION**
 
-    This variable indicates that the asset compilation process will be skipped. Since this only takes place
+    This variable set to `true` indicates that the asset compilation process will be skipped. Since this only takes place
     when the application is run in the `production` environment, it should only be used when assets are already compiled.
 
 Hot deploy


### PR DESCRIPTION
The asset compilation should be skipped only if the DISABLE_ASSET_COMPILATION env var is set to a meaningful value, which should be `true`

@mfojtik PTAL 