### PR TITLE
move newer image into centos/rhscl namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,7 @@
-SKIP_SQUASH?=0
-VERSIONS="2.0 2.2"
+# Variables are documented in hack/build.sh.
+BASE_IMAGE_NAME = ruby
+VERSIONS = 2.0 2.2
+OPENSHIFT_NAMESPACES = 2.0
 
-ifeq ($(TARGET),rhel7)
-	OS := rhel7
-else
-	OS := centos7
-endif
-
-ifeq ($(VERSION), 2.0)
-	VERSION := 2.0
-else ifeq ($(VERSION), 2.2)
-	VERSION := 2.2
-else
-	VERSION :=
-endif
-
-.PHONY: build
-build:
-	SKIP_SQUASH=$(SKIP_SQUASH) VERSIONS=$(VERSIONS) hack/build.sh $(OS) $(VERSION)
-
-.PHONY: test
-test:
-	SKIP_SQUASH=$(SKIP_SQUASH) VERSIONS=$(VERSIONS) TAG_ON_SUCCESS=$(TAG_ON_SUCCESS) TEST_MODE=true hack/build.sh $(OS) $(VERSION)
+# Include common Makefile code.
+include hack/common.mk

--- a/hack/common.mk
+++ b/hack/common.mk
@@ -1,0 +1,25 @@
+SKIP_SQUASH?=0
+
+build = hack/build.sh
+
+ifeq ($(TARGET),rhel7)
+	OS := rhel7
+else
+	OS := centos7
+endif
+
+script_env = \
+	SKIP_SQUASH=$(SKIP_SQUASH)                      \
+	VERSIONS="$(VERSIONS)"                          \
+	OS=$(OS)                                        \
+	VERSION=$(VERSION)                              \
+	BASE_IMAGE_NAME=$(BASE_IMAGE_NAME)              \
+	OPENSHIFT_NAMESPACES="$(OPENSHIFT_NAMESPACES)"
+
+.PHONY: build
+build:
+	$(script_env) $(build)
+
+.PHONY: test
+test:
+	$(script_env) TAG_ON_SUCCESS=$(TAG_ON_SUCCESS) TEST_MODE=true $(build)


### PR DESCRIPTION
While we are on it, also unify the build scripts among images'
repositories:

- hack/ directory should be _just_ mirrored
- Makefile should be as declarative as possible
- build.sh should not rely on repository name