### PR TITLE
Split README.md to usage and general part

### DIFF
--- a/2.0/README.md
+++ b/2.0/README.md
@@ -1,0 +1,137 @@
+Ruby Docker image
+=================
+
+This repository contains the source for building various versions of
+the Ruby application as a reproducible Docker image using
+[source-to-image](https://github.com/openshift/source-to-image).
+Users can choose between RHEL and CentOS based builder images.
+The resulting image can be run using [Docker](http://docker.io).
+
+
+Usage
+---------------------
+To build a simple [ruby-sample-app](https://github.com/openshift/sti-ruby/tree/master/2.0/test/puma-test-app) application
+using standalone [S2I](https://github.com/openshift/source-to-image) and then run the
+resulting image with [Docker](http://docker.io) execute:
+
+*  **For RHEL based image**
+    ```
+    $ s2i build https://github.com/openshift/sti-ruby.git --context-dir=2.0/test/puma-test-app/ openshift/ruby-20-rhel7 ruby-sample-app
+    $ docker run -p 8080:8080 ruby-sample-app
+    ```
+
+*  **For CentOS based image**
+    ```
+    $ s2i build https://github.com/openshift/sti-ruby.git --context-dir=2.0/test/puma-test-app/ openshift/ruby-20-centos7 ruby-sample-app
+    $ docker run -p 8080:8080 ruby-sample-app
+    ```
+
+**Accessing the application:**
+```
+$ curl 127.0.0.1:8080
+```
+
+
+Repository organization
+------------------------
+* **`<ruby-version>`**
+
+    * **Dockerfile**
+
+        CentOS based Dockerfile.
+
+    * **Dockerfile.rhel7**
+
+        RHEL based Dockerfile. In order to perform build or test actions on this
+        Dockerfile you need to run the action on a properly subscribed RHEL machine.
+
+    * **`s2i/bin/`**
+
+        This folder contains scripts that are run by [S2I](https://github.com/openshift/source-to-image):
+
+        *   **assemble**
+
+            Used to install the sources into the location where the application
+            will be run and prepare the application for deployment (eg. installing
+            modules using bundler, etc.)
+
+        *   **run**
+
+            This script is responsible for running the application by using the
+            application web server.
+
+        *   **usage***
+
+            This script prints the usage of this image.
+
+    * **`contrib/`**
+
+        This folder contains a file with commonly used modules.
+
+    * **`test/`**
+
+        This folder contains a [S2I](https://github.com/openshift/source-to-image)
+        test framework with a simple Rack server.
+
+        * **`puma-test-app/`**
+
+            Simple Puma web server used for testing purposes by the [S2I](https://github.com/openshift/source-to-image) test framework.
+
+        * **`rack-test-app/`**
+
+            Simple Rack web server used for testing purposes by the [S2I](https://github.com/openshift/source-to-image) test framework.
+
+        * **run**
+
+            Script that runs the [S2I](https://github.com/openshift/source-to-image) test framework.
+
+
+Environment variables
+---------------------
+
+To set these environment variables, you can place them as a key value pair into a `.sti/environment`
+file inside your source code repository.
+
+* **RACK_ENV**
+
+    This variable specifies the environment where the Ruby application will be deployed (unless overwritten) - `production`, `development`, `test`.
+    Each level has different behaviors in terms of logging verbosity, error pages, ruby gem installation, etc.
+
+    **Note**: Application assets will be compiled only if the `RACK_ENV` is set to `production`
+
+* **DISABLE_ASSET_COMPILATION**
+
+    This variable set to `true` indicates that the asset compilation process will be skipped. Since this only takes place
+    when the application is run in the `production` environment, it should only be used when assets are already compiled.
+
+Hot deploy
+---------------------
+In order to dynamically pick up changes made in your application source code, you need to make following steps:
+
+*  **For Ruby on Rails applications**
+
+    Run the built Rails image with the `RAILS_ENV=development` environment variable passed to the [Docker](http://docker.io) `-e` run flag:
+    ```
+    $ docker run -e RAILS_ENV=development -p 8080:8080 rails-app
+    ```
+*  **For other types of Ruby applications (Sinatra, Padrino, etc.)**
+
+    Your application needs to be built with one of gems that reloads the server every time changes in source code are done inside the running container. Those gems are:
+    * [Shotgun](https://github.com/rtomayko/shotgun)
+    * [Rerun](https://github.com/alexch/rerun)
+    * [Rack-livereload](https://github.com/johnbintz/rack-livereload)
+
+    Please note that in order to be able to run your application in development mode, you need to modify the [S2I run script](https://github.com/openshift/source-to-image#anatomy-of-a-builder-image), so the web server is launched by the chosen gem, which checks for changes in the source code.
+
+    After you built your application image with your version of [S2I run script](https://github.com/openshift/source-to-image#anatomy-of-a-builder-image), run the image with the RACK_ENV=development environment variable passed to the [Docker](http://docker.io) -e run flag:
+    ```
+    $ docker run -e RACK_ENV=development -p 8080:8080 sinatra-app
+    ```
+
+To change your source code in running container, use Docker's [exec](http://docker.io) command:
+```
+docker exec -it <CONTAINER_ID> /bin/bash
+```
+
+After you [Docker exec](http://docker.io) into the running container, your current
+directory is set to `/opt/app-root/src`, where the source code is located.

--- a/2.2/README.md
+++ b/2.2/README.md
@@ -1,0 +1,137 @@
+Ruby Docker image
+=================
+
+This repository contains the source for building various versions of
+the Ruby application as a reproducible Docker image using
+[source-to-image](https://github.com/openshift/source-to-image).
+Users can choose between RHEL and CentOS based builder images.
+The resulting image can be run using [Docker](http://docker.io).
+
+
+Usage
+---------------------
+To build a simple [ruby-sample-app](https://github.com/openshift/sti-ruby/tree/master/2.2/test/puma-test-app) application
+using standalone [S2I](https://github.com/openshift/source-to-image) and then run the
+resulting image with [Docker](http://docker.io) execute:
+
+*  **For RHEL based image**
+    ```
+    $ s2i build https://github.com/openshift/sti-ruby.git --context-dir=2.2/test/puma-test-app/ rhscl/ruby-22-rhel7 ruby-sample-app
+    $ docker run -p 8080:8080 ruby-sample-app
+    ```
+
+*  **For CentOS based image**
+    ```
+    $ s2i build https://github.com/openshift/sti-ruby.git --context-dir=2.2/test/puma-test-app/ centos/ruby-22-centos7 ruby-sample-app
+    $ docker run -p 8080:8080 ruby-sample-app
+    ```
+
+**Accessing the application:**
+```
+$ curl 127.0.0.1:8080
+```
+
+
+Repository organization
+------------------------
+* **`<ruby-version>`**
+
+    * **Dockerfile**
+
+        CentOS based Dockerfile.
+
+    * **Dockerfile.rhel7**
+
+        RHEL based Dockerfile. In order to perform build or test actions on this
+        Dockerfile you need to run the action on a properly subscribed RHEL machine.
+
+    * **`s2i/bin/`**
+
+        This folder contains scripts that are run by [S2I](https://github.com/openshift/source-to-image):
+
+        *   **assemble**
+
+            Used to install the sources into the location where the application
+            will be run and prepare the application for deployment (eg. installing
+            modules using bundler, etc.)
+
+        *   **run**
+
+            This script is responsible for running the application by using the
+            application web server.
+
+        *   **usage***
+
+            This script prints the usage of this image.
+
+    * **`contrib/`**
+
+        This folder contains a file with commonly used modules.
+
+    * **`test/`**
+
+        This folder contains a [S2I](https://github.com/openshift/source-to-image)
+        test framework with a simple Rack server.
+
+        * **`puma-test-app/`**
+
+            Simple Puma web server used for testing purposes by the [S2I](https://github.com/openshift/source-to-image) test framework.
+
+        * **`rack-test-app/`**
+
+            Simple Rack web server used for testing purposes by the [S2I](https://github.com/openshift/source-to-image) test framework.
+
+        * **run**
+
+            Script that runs the [S2I](https://github.com/openshift/source-to-image) test framework.
+
+
+Environment variables
+---------------------
+
+To set these environment variables, you can place them as a key value pair into a `.sti/environment`
+file inside your source code repository.
+
+* **RACK_ENV**
+
+    This variable specifies the environment where the Ruby application will be deployed (unless overwritten) - `production`, `development`, `test`.
+    Each level has different behaviors in terms of logging verbosity, error pages, ruby gem installation, etc.
+
+    **Note**: Application assets will be compiled only if the `RACK_ENV` is set to `production`
+
+* **DISABLE_ASSET_COMPILATION**
+
+    This variable set to `true` indicates that the asset compilation process will be skipped. Since this only takes place
+    when the application is run in the `production` environment, it should only be used when assets are already compiled.
+
+Hot deploy
+---------------------
+In order to dynamically pick up changes made in your application source code, you need to make following steps:
+
+*  **For Ruby on Rails applications**
+
+    Run the built Rails image with the `RAILS_ENV=development` environment variable passed to the [Docker](http://docker.io) `-e` run flag:
+    ```
+    $ docker run -e RAILS_ENV=development -p 8080:8080 rails-app
+    ```
+*  **For other types of Ruby applications (Sinatra, Padrino, etc.)**
+
+    Your application needs to be built with one of gems that reloads the server every time changes in source code are done inside the running container. Those gems are:
+    * [Shotgun](https://github.com/rtomayko/shotgun)
+    * [Rerun](https://github.com/alexch/rerun)
+    * [Rack-livereload](https://github.com/johnbintz/rack-livereload)
+
+    Please note that in order to be able to run your application in development mode, you need to modify the [S2I run script](https://github.com/openshift/source-to-image#anatomy-of-a-builder-image), so the web server is launched by the chosen gem, which checks for changes in the source code.
+
+    After you built your application image with your version of [S2I run script](https://github.com/openshift/source-to-image#anatomy-of-a-builder-image), run the image with the RACK_ENV=development environment variable passed to the [Docker](http://docker.io) -e run flag:
+    ```
+    $ docker run -e RACK_ENV=development -p 8080:8080 sinatra-app
+    ```
+
+To change your source code in running container, use Docker's [exec](http://docker.io) command:
+```
+docker exec -it <CONTAINER_ID> /bin/bash
+```
+
+After you [Docker exec](http://docker.io) into the running container, your current
+directory is set to `/opt/app-root/src`, where the source code is located.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Ruby for OpenShift - Docker images
-========================================
+Ruby Docker images
+==================
 
 This repository contains the source for building various versions of
 the Ruby application as a reproducible Docker image using
@@ -55,28 +55,15 @@ To build a Ruby image, choose either the CentOS or RHEL based image:
 on all provided versions of Ruby.**
 
 
+
 Usage
----------------------
-To build a simple [ruby-sample-app](https://github.com/openshift/sti-ruby/tree/master/2.0/test/puma-test-app) application
-using standalone [S2I](https://github.com/openshift/source-to-image) and then run the
-resulting image with [Docker](http://docker.io) execute:
+---------------------------------
 
-*  **For RHEL based image**
-    ```
-    $ s2i build https://github.com/openshift/sti-ruby.git --context-dir=2.0/test/puma-test-app/ openshift/ruby-20-rhel7 ruby-sample-app
-    $ docker run -p 8080:8080 ruby-sample-app
-    ```
+For information about usage of Dockerfile for Ruby 2.0,
+see [usage documentation](2.0/README.md).
 
-*  **For CentOS based image**
-    ```
-    $ s2i build https://github.com/openshift/sti-ruby.git --context-dir=2.0/test/puma-test-app/ openshift/ruby-20-centos7 ruby-sample-app
-    $ docker run -p 8080:8080 ruby-sample-app
-    ```
-
-**Accessing the application:**
-```
-$ curl 127.0.0.1:8080
-```
+For information about usage of Dockerfile for Ruby 2.2,
+see [usage documentation](2.2/README.md).
 
 
 Test
@@ -111,54 +98,7 @@ Repository organization
 ------------------------
 * **`<ruby-version>`**
 
-    * **Dockerfile**
-
-        CentOS based Dockerfile.
-
-    * **Dockerfile.rhel7**
-
-        RHEL based Dockerfile. In order to perform build or test actions on this
-        Dockerfile you need to run the action on a properly subscribed RHEL machine.
-
-    * **`s2i/bin/`**
-
-        This folder contains scripts that are run by [S2I](https://github.com/openshift/source-to-image):
-
-        *   **assemble**
-
-            Used to install the sources into the location where the application
-            will be run and prepare the application for deployment (eg. installing
-            modules using bundler, etc.)
-
-        *   **run**
-
-            This script is responsible for running the application by using the
-            application web server.
-
-        *   **usage***
-
-            This script prints the usage of this image.
-
-    * **`contrib/`**
-
-        This folder contains a file with commonly used modules.
-
-    * **`test/`**
-
-        This folder contains a [S2I](https://github.com/openshift/source-to-image)
-        test framework with a simple Rack server.
-
-        * **`puma-test-app/`**
-
-            Simple Puma web server used for testing purposes by the [S2I](https://github.com/openshift/source-to-image) test framework.
-
-        * **`rack-test-app/`**
-
-            Simple Rack web server used for testing purposes by the [S2I](https://github.com/openshift/source-to-image) test framework.
-
-        * **run**
-
-            Script that runs the [S2I](https://github.com/openshift/source-to-image) test framework.
+    Dockerfile and scripts to build container images from.
 
 * **`hack/`**
 
@@ -175,53 +115,3 @@ Image name structure
 
 Examples: `openshift/ruby-20-centos7`, `openshift/ruby-20-rhel7`
 
-
-Environment variables
----------------------
-
-To set these environment variables, you can place them as a key value pair into a `.sti/environment`
-file inside your source code repository.
-
-* **RACK_ENV**
-
-    This variable specifies the environment where the Ruby application will be deployed (unless overwritten) - `production`, `development`, `test`.
-    Each level has different behaviors in terms of logging verbosity, error pages, ruby gem installation, etc.
-
-    **Note**: Application assets will be compiled only if the `RACK_ENV` is set to `production`
-
-* **DISABLE_ASSET_COMPILATION**
-
-    This variable set to `true` indicates that the asset compilation process will be skipped. Since this only takes place
-    when the application is run in the `production` environment, it should only be used when assets are already compiled.
-
-Hot deploy
----------------------
-In order to dynamically pick up changes made in your application source code, you need to make following steps:
-
-*  **For Ruby on Rails applications**
-
-    Run the built Rails image with the `RAILS_ENV=development` environment variable passed to the [Docker](http://docker.io) `-e` run flag:
-    ```
-    $ docker run -e RAILS_ENV=development -p 8080:8080 rails-app
-    ```
-*  **For other types of Ruby applications (Sinatra, Padrino, etc.)**
-
-    Your application needs to be built with one of gems that reloads the server every time changes in source code are done inside the running container. Those gems are:
-    * [Shotgun](https://github.com/rtomayko/shotgun)
-    * [Rerun](https://github.com/alexch/rerun)
-    * [Rack-livereload](https://github.com/johnbintz/rack-livereload)
-
-    Please note that in order to be able to run your application in development mode, you need to modify the [S2I run script](https://github.com/openshift/source-to-image#anatomy-of-a-builder-image), so the web server is launched by the chosen gem, which checks for changes in the source code.
-
-    After you built your application image with your version of [S2I run script](https://github.com/openshift/source-to-image#anatomy-of-a-builder-image), run the image with the RACK_ENV=development environment variable passed to the [Docker](http://docker.io) -e run flag:
-    ```
-    $ docker run -e RACK_ENV=development -p 8080:8080 sinatra-app
-    ```
-
-To change your source code in running container, use Docker's [exec](http://docker.io) command:
-```
-docker exec -it <CONTAINER_ID> /bin/bash
-```
-
-After you [Docker exec](http://docker.io) into the running container, your current
-directory is set to `/opt/app-root/src`, where the source code is located.


### PR DESCRIPTION
This is similar to https://github.com/openshift/mysql/pull/99. It allows us to maintain two separate variant for every version (default values, image names, links to doc and eventually more, that may be or already is different). As a bonus, we'll have a clean `README.md` with only image-related usage information that can be used in Docker Hub or elsewhere.