### PR TITLE
Use the whole commit ID for the builder-version LABEL

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -34,7 +34,7 @@ function docker_build_with_version {
   # Use perl here to make this compatible with OSX
   DOCKERFILE_PATH=$(perl -MCwd -e 'print Cwd::abs_path shift' $dockerfile)
   cp ${DOCKERFILE_PATH} "${DOCKERFILE_PATH}.version"
-  git_version=$(git rev-parse --short HEAD)
+  git_version=$(git rev-parse HEAD)
   echo "LABEL io.openshift.builder-version=\"${git_version}\"" >> "${dockerfile}.version"
   docker build -t ${IMAGE_NAME} -f "${dockerfile}.version" .
   if [[ "${SKIP_SQUASH}" != "1" ]]; then


### PR DESCRIPTION
Since we make https://github.com/openshift/source-to-image/pull/304 change for s2i builds it would make sense that the builder-version LABEL will have the long version as well.

@bparees PTAL  