### PR TITLE
Add support for REGISTRY parameter when in test mode

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -90,6 +90,11 @@ for dir in ${dirs}; do
       echo "-> Re-tagging ${IMAGE_NAME} image to ${IMAGE_NAME%"-candidate"}"
       docker tag -f $IMAGE_NAME ${IMAGE_NAME%"-candidate"}
     fi
+
+    if [[ ! -z "${REGISTRY}" ]]; then
+      echo "-> Tagging image as" ${REGISTRY}/${IMAGE_NAME%"-candidate"}
+      docker tag -f $IMAGE_NAME ${REGISTRY}/${IMAGE_NAME%"-candidate"}
+    fi
   fi
 
   popd > /dev/null


### PR DESCRIPTION
Running this command:

```
REGISTRY="foo:5000" make test TARGET=rhel7
```

Will cause the image be tagged as "foo:5000/ruby-20-rhel7" after the test finishes.
This allows to consume the image in extended test or other tests that want to pull the image.