### PR TITLE
WIP: Allow users to specify what command to run tests

### DIFF
--- a/2.2/README.md
+++ b/2.2/README.md
@@ -92,6 +92,14 @@ Environment variables
 To set these environment variables, you can place them as a key value pair into a `.sti/environment`
 file inside your source code repository.
 
+* **RUN_TEST**
+
+    This variable allows you to define a command used to execute the test suite
+    as part of the "assemble" process. Setting this to `rake test` will execute
+    this command after all dependencies are successfully installed.
+    Note that all environment variables specified for the build (`assemble`) are
+    passed to the command defined in `RUN_TEST`.
+
 * **RACK_ENV**
 
     This variable specifies the environment where the Ruby application will be deployed (unless overwritten) - `production`, `development`, `test`.

--- a/2.2/s2i/bin/assemble
+++ b/2.2/s2i/bin/assemble
@@ -50,6 +50,11 @@ if [[ "$RAILS_ENV" == "production" || "$RACK_ENV" == "production" ]]; then
   rake_assets_precompile
 fi
 
+if [[ ! -z "${RUN_TEST}" ]]; then
+  echo "---> Running tests using '$RUN_TEST' ..."
+  $RUN_TEST
+fi
+
 # Fix source directory permissions
 fix-permissions ./
 

--- a/2.2/test/puma-test-app/Gemfile
+++ b/2.2/test/puma-test-app/Gemfile
@@ -2,3 +2,6 @@ source 'https://rubygems.org'
 
 gem 'sinatra'
 gem 'puma'
+gem 'rack'
+gem 'rake'
+gem 'minitest'

--- a/2.2/test/puma-test-app/Gemfile.lock
+++ b/2.2/test/puma-test-app/Gemfile.lock
@@ -1,11 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    minitest (4.3.2)
     puma (2.8.2)
       rack (>= 1.1, < 2.0)
     rack (1.5.2)
     rack-protection (1.5.0)
       rack
+    rake (0.9.6)
     sinatra (1.4.5)
       rack (~> 1.4)
       rack-protection (~> 1.4)
@@ -16,5 +18,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  minitest
   puma
+  rack
+  rake
   sinatra
+
+BUNDLED WITH
+   1.11.2

--- a/2.2/test/puma-test-app/Rakefile
+++ b/2.2/test/puma-test-app/Rakefile
@@ -1,0 +1,8 @@
+require 'bundler'
+
+require 'rake/testtask'
+
+Rake::TestTask.new do |t|
+  t.pattern = "test/*_test.rb"
+  t.verbose = true
+end

--- a/2.2/test/puma-test-app/test/sample_test.rb
+++ b/2.2/test/puma-test-app/test/sample_test.rb
@@ -1,0 +1,8 @@
+require 'bundler'
+require 'minitest/autorun'
+
+class TestSample < Minitest::Unit::TestCase
+  def test_sample
+    assert_equal "Foo", "Foo"
+  end
+end

--- a/2.2/test/run
+++ b/2.2/test/run
@@ -38,6 +38,10 @@ run_s2i_build() {
   s2i build ${s2i_args} file://${test_dir}/${1}-test-app ${IMAGE_NAME} ${IMAGE_NAME}-testapp
 }
 
+run_s2i_build_with_test() {
+  s2i build -e RUN_TEST="bundle exec rake test" ${s2i_args} file://${test_dir}/${1}-test-app ${IMAGE_NAME} ${IMAGE_NAME}-testapp
+}
+
 prepare() {
   if ! image_exists ${IMAGE_NAME}; then
     echo "ERROR: The image ${IMAGE_NAME} must exist before this script is executed."
@@ -161,7 +165,11 @@ for server in ${WEB_SERVERS[@]}; do
   s2i_args="--force-pull=false"
 
   prepare ${server}
-  run_s2i_build ${server}
+  if [[ "${server}" == "puma" ]]; then
+    run_s2i_build_with_test ${server}
+  else
+    run_s2i_build ${server}
+  fi
   check_result $?
 
   # Verify the 'usage' script is working properly when running the base image with 's2i usage ...'


### PR DESCRIPTION
This PR will allow to specify what command to run as a "test" command by setting the `RUN_TEST` variable.

The command specified by this environment variable will be executed by the `assemble` script when installed all dependencies. If this variable is set and it fails (returns non-zero) the assemble will fail.

For the S2I this variable can be specified by using the command line `-e RUN_TEST="bundle exec rake test" ` in OpenShift you can specify this in the `BuildConfig` as any other environment variable.
In OpenShift, when the test fail, the image will not be produced.

This also allows to pass any additional variable to the build to customize the test run ($RUN_TEST pick up any variable specified for `assemble`).