### PR TITLE
Enable configuration of Puma's thread pool size

### DIFF
--- a/2.0/contrib/etc/puma.cfg
+++ b/2.0/contrib/etc/puma.cfg
@@ -1,4 +1,40 @@
+def get_max_memory()
+    return ENV['MEMORY_LIMIT_IN_BYTES'].to_i if ENV.has_key? 'MEMORY_LIMIT_IN_BYTES'
+
+    # Assume unlimited memory. 0.size is the number of bytes a Ruby
+    # Fixnum class can hold. One bit is used for sign and one is used
+    # by Ruby to determine whether it's a number or pointer to an object.
+    # That's why we subtract two bits. This expresion should therefore be
+    # the largest signed Fixnum possible.
+    (2 ** (8*0.size - 2) - 1)
+end
+
+def get_min_threads()
+    ENV.fetch('PUMA_MIN_THREADS', '0').to_i
+end
+
+def get_max_threads()
+    ENV.fetch('PUMA_MAX_THREADS', '16').to_i
+end
+
+# Determine the maximum number of workers that are allowed by the available
+# memory. Puma documentation recommends the maximum number of workers to be
+# set to the number cores.
+def get_workers()
+    return ENV['PUMA_WORKERS'].to_i if ENV.has_key? 'PUMA_WORKERS'
+
+    base_memory = 50 * 1024 * 1024
+    per_worker_base_memory = 15 * 1024 * 1024
+    per_thread_memory = 128 * 1024
+
+    cores = ENV.fetch('NUMBER_OF_CORES', '1').to_i
+    per_worker_memory = per_worker_base_memory + per_thread_memory*get_max_threads()
+    max_workers = (get_max_memory() - base_memory) / per_worker_memory
+
+    [cores, max_workers].min
+end
+
 environment ENV['RACK_ENV'] || ENV['RAILS_ENV'] || 'production'
-threads     0, 16
-workers     0
+threads     get_min_threads(), get_max_threads()
+workers     get_workers()
 bind        'tcp://0.0.0.0:8080'

--- a/2.0/s2i/bin/run
+++ b/2.0/s2i/bin/run
@@ -7,9 +7,21 @@ function is_puma_installed() {
 
 set -e
 
+function check_number() {
+  if [[ ! "$2" =~ ^[0-9]+$ ]]; then
+    echo "$1 needs to be a non-negative number"
+    exit 1
+  fi
+}
+check_number PUMA_WORKERS     "${PUMA_WORKERS:-0}"
+check_number PUMA_MIN_THREADS "${PUMA_MIN_THREADS:-0}"
+check_number PUMA_MAX_THREADS "${PUMA_MAX_THREADS:-0}"
+
 export RACK_ENV=${RACK_ENV:-"production"}
 
 if is_puma_installed; then
+  export_vars=$(cgroup-limits) ; export $export_vars
+
   exec bundle exec "puma --config ../etc/puma.cfg"
 else
   echo "You might consider adding 'puma' into your Gemfile."
@@ -25,4 +37,3 @@ else
     echo "       Add rack to your Gemfile in order to start the web server."
   fi
 fi
-

--- a/2.2/contrib/etc/puma.cfg
+++ b/2.2/contrib/etc/puma.cfg
@@ -1,4 +1,40 @@
+def get_max_memory()
+    return ENV['MEMORY_LIMIT_IN_BYTES'].to_i if ENV.has_key? 'MEMORY_LIMIT_IN_BYTES'
+
+    # Assume unlimited memory. 0.size is the number of bytes a Ruby
+    # Fixnum class can hold. One bit is used for sign and one is used
+    # by Ruby to determine whether it's a number or pointer to an object.
+    # That's why we subtract two bits. This expresion should therefore be
+    # the largest signed Fixnum possible.
+    (2 ** (8*0.size - 2) - 1)
+end
+
+def get_min_threads()
+    ENV.fetch('PUMA_MIN_THREADS', '0').to_i
+end
+
+def get_max_threads()
+    ENV.fetch('PUMA_MAX_THREADS', '16').to_i
+end
+
+# Determine the maximum number of workers that are allowed by the available
+# memory. Puma documentation recommends the maximum number of workers to be
+# set to the number cores.
+def get_workers()
+    return ENV['PUMA_WORKERS'].to_i if ENV.has_key? 'PUMA_WORKERS'
+
+    base_memory = 50 * 1024 * 1024
+    per_worker_base_memory = 15 * 1024 * 1024
+    per_thread_memory = 128 * 1024
+
+    cores = ENV.fetch('NUMBER_OF_CORES', '1').to_i
+    per_worker_memory = per_worker_base_memory + per_thread_memory*get_max_threads()
+    max_workers = (get_max_memory() - base_memory) / per_worker_memory
+
+    [cores, max_workers].min
+end
+
 environment ENV['RACK_ENV'] || ENV['RAILS_ENV'] || 'production'
-threads     0, 16
-workers     0
+threads     get_min_threads(), get_max_threads()
+workers     get_workers()
 bind        'tcp://0.0.0.0:8080'

--- a/2.2/s2i/bin/run
+++ b/2.2/s2i/bin/run
@@ -7,9 +7,21 @@ function is_puma_installed() {
 
 set -e
 
+function check_number() {
+  if [[ ! "$2" =~ ^[0-9]+$ ]]; then
+    echo "$1 needs to be a non-negative number"
+    exit 1
+  fi
+}
+check_number PUMA_WORKERS     "${PUMA_WORKERS:-0}"
+check_number PUMA_MIN_THREADS "${PUMA_MIN_THREADS:-0}"
+check_number PUMA_MAX_THREADS "${PUMA_MAX_THREADS:-0}"
+
 export RACK_ENV=${RACK_ENV:-"production"}
 
 if is_puma_installed; then
+  export_vars=$(cgroup-limits) ; export $export_vars
+
   exec bundle exec "puma --config ../etc/puma.cfg"
 else
   echo "You might consider adding 'puma' into your Gemfile."


### PR DESCRIPTION
Add two configuration variables for determining Puma's thread pool size,
`PUMA_MIN_THREADS` and `PUMA_MAX_THREADS`.

Trello: https://trello.com/c/kvzlecgq/853-5-tune-ruby-based-on-memory-limits-evg