### PR TITLE
Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+sudo: required
+
+services:
+  - docker
+
+language: go
+
+go: 1.6
+
+install:
+  - go get github.com/openshift/source-to-image
+  - pushd ${GOPATH}/src/github.com/openshift/source-to-image
+  - export PATH=$PATH:${GOPATH}/src/github.com/openshift/source-to-image/_output/local/bin/linux/amd64/
+  - hack/build-go.sh
+  - popd
+
+script: make test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 Ruby Docker images
 ==================
 
+[![Build Status](https://travis-ci.org/openshift/sti-ruby.svg?branch=master)](https://travis-ci.org/openshift/sti-ruby)
+
+
 This repository contains the source for building various versions of
 the Ruby application as a reproducible Docker image using
 [source-to-image](https://github.com/openshift/source-to-image).


### PR DESCRIPTION
Let travis-ci.org test the image for you. Someone has to log into travis-ci.org to activate the build for this repository.