### PR TITLE
Read test port from image meta data.

### DIFF
--- a/2.0/test/run
+++ b/2.0/test/run
@@ -15,8 +15,8 @@ declare -a WEB_SERVERS=(db puma rack)
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 image_dir=$(readlink -zf ${test_dir}/..)
 
-# TODO: This should be part of the image metadata
-test_port=8080
+# Read exposed port from image meta data
+test_port="$(docker inspect --format='{{range $key, $value := .ContainerConfig.ExposedPorts }}{{$key}}{{end}}' ${IMAGE_NAME} | sed 's/\/.*//')"
 
 info() {
   echo -e "\n\e[1m[INFO] $@...\e[0m\n"

--- a/2.2/test/run
+++ b/2.2/test/run
@@ -15,8 +15,8 @@ declare -a WEB_SERVERS=(db puma rack)
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 image_dir=$(readlink -zf ${test_dir}/..)
 
-# TODO: This should be part of the image metadata
-test_port=8080
+# Read exposed port from image meta data
+test_port="$(docker inspect --format='{{range $key, $value := .ContainerConfig.ExposedPorts }}{{$key}}{{end}}' ${IMAGE_NAME} | sed 's/\/.*//')"
 
 info() {
   echo -e "\n\e[1m[INFO] $@...\e[0m\n"


### PR DESCRIPTION
This will only work if the image only exposes one port. Fixes the TODO in the test/run scripts.