### PR TITLE
Fix travis build by only testing the centos7 image.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ install:
   - hack/build-go.sh
   - popd
 
-script: make test
+script: make test TARGET=centos7


### PR DESCRIPTION
The RHEL build seems to fail, so we only build the centos7 image, as
suggested by Ben Parees. This fixes #100.